### PR TITLE
fix eslint import order

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import fs from 'fs';
+import axios from 'axios';
 import { buildQueryString, encodeFileName } from './utils';
 import UploadResult from './upload_result';
 import Error from './error';


### PR DESCRIPTION
Fix following `eslint-import` error:
```
/Users/shashank/.npm/_cacache/tmp/git-cloneMPlDVE/src/client.js
npm ERR!   2:1  error  `fs` import should occur before import of `axios`  import/order
npm ERR!
npm ERR! ✖ 1 problem (1 error, 0 warnings)
npm ERR!   1 error, 0 warnings potentially fixable with the `--fix` option.
