### PR TITLE
Upgraded Axios to 0.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/ConvertAPI/convertapi-node#readme",
   "dependencies": {
-    "axios": "^0.21.1"
+    "axios": "^0.28.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
Upgraded Axios to 0.28.1. This is done to resolve the Axios alert in the Sprinto App.